### PR TITLE
Fix <div> tag and function definition in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,13 +71,13 @@ Here is an example template:
 ```jsx
 ...
 
-export default BlogPage = ({ data }) => {
+export default ({ data }) => {
   const { page } = data.wagtail
 
   return (
     <div>
       <h1>{ page.title }</h1>
-    <div>
+    </div>
   )
 }
 


### PR DESCRIPTION
This snippet is not JS valid. 
`export default ({ data }) => {`
or `const BlogPage = ({ data }) => {`
or `export default function BlogPage({ data }) {`
would be valid. 

Also, the `<div>` tag is wrongly closed 😁