### PR TITLE
Fix useStaticQuery hooks broken by gatsby-source-wagtail

### DIFF
--- a/src/babel-plugin-remove-graphql-queries.js
+++ b/src/babel-plugin-remove-graphql-queries.js
@@ -417,9 +417,7 @@ export default function({ types: t }) {
             // See if the query is a variable that's being passed in
             // and if it is, go find it.
             if (
-              hookPath.node.callee.name !== `useStaticQuery` ||
               hookPath.node.arguments.length === 1 &&
-              !hookPath.get(`callee`).referencesImport(`gatsby`)
               hookPath.node.arguments[0].type === `Identifier`
             ) {
               return
@@ -431,10 +429,9 @@ export default function({ types: t }) {
                 })
               }
             }
-
             hookPath.traverse({
               // Assume the query is inline in the component and extract that.
-							TaggedTemplateExpression
+              TaggedTemplateExpression
             })
           },
         })

--- a/src/babel-plugin-remove-graphql-queries.js
+++ b/src/babel-plugin-remove-graphql-queries.js
@@ -1,6 +1,7 @@
 /*  eslint-disable new-cap */
 const graphql = require(`gatsby/graphql`)
-const murmurhash = require(`babel-plugin-remove-graphql-queries/murmur`)
+const murmurModule = require(`babel-plugin-remove-graphql-queries/murmur`);
+const murmurhash = typeof murmurModule === 'function' ? murmurModule : murmurModule.murmurhash;
 const nodePath = require(`path`)
 
 const isGlobalIdentifier = tag =>

--- a/src/babel-plugin-remove-graphql-queries.js
+++ b/src/babel-plugin-remove-graphql-queries.js
@@ -29,6 +29,37 @@ function getGraphqlExpr(t, queryHash, source, ast) {
   ])
 }
 
+class StringInterpolationNotAllowedError extends Error {
+  constructor(interpolationStart, interpolationEnd) {
+    super(
+      `BabelPluginRemoveGraphQLQueries: String interpolations are not allowed in graphql ` +
+        `fragments. Included fragments should be referenced ` +
+        `as \`...MyModule_foo\`.`
+    )
+    this.interpolationStart = JSON.parse(JSON.stringify(interpolationStart))
+    this.interpolationEnd = JSON.parse(JSON.stringify(interpolationEnd))
+    Error.captureStackTrace(this, StringInterpolationNotAllowedError)
+  }
+}
+class EmptyGraphQLTagError extends Error {
+  constructor(locationOfGraphqlString) {
+    super(`BabelPluginRemoveGraphQLQueries: Unexpected empty graphql tag.`)
+    this.templateLoc = locationOfGraphqlString
+    Error.captureStackTrace(this, EmptyGraphQLTagError)
+  }
+}
+class GraphQLSyntaxError extends Error {
+  constructor(documentText, originalError, locationOfGraphqlString) {
+    super(
+      `BabelPluginRemoveGraphQLQueries: GraphQL syntax error in query:\n\n${documentText}\n\nmessage:\n\n${originalError}`
+    )
+    this.documentText = documentText
+    this.originalError = originalError
+    this.templateLoc = locationOfGraphqlString
+    Error.captureStackTrace(this, GraphQLSyntaxError)
+  }
+}
+
 function getTagImport(tag) {
   const name = tag.node.name
   const binding = tag.scope.getBinding(name)
@@ -124,10 +155,11 @@ function getGraphQLTag(path) {
   const quasis = path.node.quasi.quasis
 
   if (quasis.length !== 1) {
-    throw new Error(
+    throw new StringInterpolationNotAllowedError(
       `BabelPluginRemoveGraphQL: String interpolations are not allowed in graphql ` +
+      quasis[0].loc.end,
         `fragments. Included fragments should be referenced ` +
-        `as \`...MyModule_foo\`.`
+      quasis[1].loc.start
     )
   }
 
@@ -138,7 +170,7 @@ function getGraphQLTag(path) {
     const ast = graphql.parse(text)
 
     if (ast.definitions.length === 0) {
-      throw new Error(`BabelPluginRemoveGraphQL: Unexpected empty graphql tag.`)
+      throw new EmptyGraphQLTagError(quasis[0].loc)
     }
     return { ast, text, hash, isGlobal }
   } catch (err) {
@@ -148,6 +180,19 @@ function getGraphQLTag(path) {
       }`
     )
   }
+}
+
+function isUseStaticQuery(path) {
+  return (
+    (path.node.callee.type === `MemberExpression` &&
+      path.node.callee.property.name === `useStaticQuery` &&
+      path
+        .get(`callee`)
+        .get(`object`)
+        .referencesImport(`gatsby`)) ||
+    (path.node.callee.name === `useStaticQuery` &&
+      path.get(`callee`).referencesImport(`gatsby`))
+  )
 }
 
 export default function({ types: t }) {
@@ -197,8 +242,7 @@ export default function({ types: t }) {
           CallExpression(path2) {
             if (
               [`production`, `test`].includes(process.env.NODE_ENV) &&
-              path2.node.callee.name === `useStaticQuery` &&
-              path2.get(`callee`).referencesImport(`gatsby`)
+              isUseStaticQuery(path2)
             ) {
               const identifier = t.identifier(`staticQueryData`)
               const filename = state.file.opts.filename
@@ -210,12 +254,26 @@ export default function({ types: t }) {
                 this.templatePath.parentPath.remove()
               }
 
-              // Remove imports to useStaticQuery
+              // only remove the import if its like:
               const importPath = path2.scope.getBinding(`useStaticQuery`).path
+              // import { useStaticQuery } from 'gatsby'
               const parent = importPath.parentPath
+              // but not if its like:
               if (importPath.isImportSpecifier())
+              // import * as Gatsby from 'gatsby'
                 if (parent.node.specifiers.length === 1) parent.remove()
+              // because we know we can remove the useStaticQuery import,
                 else importPath.remove()
+              // but we don't know if other 'gatsby' exports are used, so we
+              // cannot remove all 'gatsby' imports.
+              if (path2.node.callee.type !== `MemberExpression`) {
+                // Remove imports to useStaticQuery
+                const importPath = path2.scope.getBinding(`useStaticQuery`).path
+                const parent = importPath.parentPath
+                if (importPath.isImportSpecifier())
+                  if (parent.node.specifiers.length === 1) parent.remove()
+                  else importPath.remove()
+              }
 
               // Add query
               path2.replaceWith(
@@ -334,42 +392,49 @@ export default function({ types: t }) {
           },
         })
 
+        function followVariableDeclarations(binding) {
+          const node = binding.path?.node
+          if (
+            node &&
+            node.type === `VariableDeclarator` &&
+            node.id.type === `Identifier` &&
+            node.init.type === `Identifier`
+          ) {
+            return followVariableDeclarations(
+              binding.path.scope.getBinding(node.init.name)
+            )
+          }
+          return binding
+        }
+
         // Traverse once again for useStaticQuery instances
         path.traverse({
           CallExpression(hookPath) {
+            if (!isUseStaticQuery(hookPath)) return
+            function TaggedTemplateExpression(templatePath) {
+              setImportForStaticQuery(templatePath)
+            }
+            // See if the query is a variable that's being passed in
+            // and if it is, go find it.
             if (
               hookPath.node.callee.name !== `useStaticQuery` ||
+              hookPath.node.arguments.length === 1 &&
               !hookPath.get(`callee`).referencesImport(`gatsby`)
+              hookPath.node.arguments[0].type === `Identifier`
             ) {
               return
+              const [{ name: varName }] = hookPath.node.arguments
+              let binding = hookPath.scope.getBinding(varName)
+              if (binding) {
+                followVariableDeclarations(binding).path.traverse({
+                  TaggedTemplateExpression,
+                })
+              }
             }
 
             hookPath.traverse({
               // Assume the query is inline in the component and extract that.
-              TaggedTemplateExpression(templatePath) {
-                setImportForStaticQuery(templatePath)
-              },
-              // // Also see if it's a variable that's passed in as a prop
-              // // and if it is, go find it.
-              Identifier(identifierPath) {
-                if (identifierPath.node.name !== `graphql`) {
-                  const varName = identifierPath.node.name
-                  path.traverse({
-                    VariableDeclarator(varPath) {
-                      if (
-                        varPath.node.id.name === varName &&
-                        varPath.node.init.type === `TaggedTemplateExpression`
-                      ) {
-                        varPath.traverse({
-                          TaggedTemplateExpression(templatePath) {
-                            setImportForStaticQuery(templatePath)
-                          },
-                        })
-                      }
-                    },
-                  })
-                }
-              },
+							TaggedTemplateExpression
             })
           },
         })
@@ -404,4 +469,9 @@ export default function({ types: t }) {
   }
 }
 
-export { getGraphQLTag }
+export {
+  getGraphQLTag,
+  StringInterpolationNotAllowedError,
+  EmptyGraphQLTagError,
+  GraphQLSyntaxError
+}

--- a/src/babel-plugin-remove-graphql-queries.js
+++ b/src/babel-plugin-remove-graphql-queries.js
@@ -33,8 +33,8 @@ class StringInterpolationNotAllowedError extends Error {
   constructor(interpolationStart, interpolationEnd) {
     super(
       `BabelPluginRemoveGraphQLQueries: String interpolations are not allowed in graphql ` +
-        `fragments. Included fragments should be referenced ` +
-        `as \`...MyModule_foo\`.`
+      `fragments. Included fragments should be referenced ` +
+      `as \`...MyModule_foo\`.`
     )
     this.interpolationStart = JSON.parse(JSON.stringify(interpolationStart))
     this.interpolationEnd = JSON.parse(JSON.stringify(interpolationEnd))
@@ -156,9 +156,7 @@ function getGraphQLTag(path) {
 
   if (quasis.length !== 1) {
     throw new StringInterpolationNotAllowedError(
-      `BabelPluginRemoveGraphQL: String interpolations are not allowed in graphql ` +
       quasis[0].loc.end,
-        `fragments. Included fragments should be referenced ` +
       quasis[1].loc.start
     )
   }
@@ -176,7 +174,7 @@ function getGraphQLTag(path) {
   } catch (err) {
     throw new Error(
       `BabelPluginRemoveGraphQLQueries: GraphQL syntax error in query:\n\n${text}\n\nmessage:\n\n${
-        err.message
+      err.message
       }`
     )
   }
@@ -195,7 +193,7 @@ function isUseStaticQuery(path) {
   )
 }
 
-export default function({ types: t }) {
+export default function ({ types: t }) {
   return {
     visitor: {
       Program(path, state) {
@@ -227,9 +225,9 @@ export default function({ types: t }) {
                 t.stringLiteral(
                   filename
                     ? nodePath.relative(
-                        nodePath.parse(filename).dir,
-                        resultPath
-                      )
+                      nodePath.parse(filename).dir,
+                      resultPath
+                    )
                     : shortResultPath
                 )
               )
@@ -254,16 +252,12 @@ export default function({ types: t }) {
                 this.templatePath.parentPath.remove()
               }
 
+
               // only remove the import if its like:
-              const importPath = path2.scope.getBinding(`useStaticQuery`).path
               // import { useStaticQuery } from 'gatsby'
-              const parent = importPath.parentPath
               // but not if its like:
-              if (importPath.isImportSpecifier())
               // import * as Gatsby from 'gatsby'
-                if (parent.node.specifiers.length === 1) parent.remove()
               // because we know we can remove the useStaticQuery import,
-                else importPath.remove()
               // but we don't know if other 'gatsby' exports are used, so we
               // cannot remove all 'gatsby' imports.
               if (path2.node.callee.type !== `MemberExpression`) {
@@ -289,9 +283,9 @@ export default function({ types: t }) {
                 t.stringLiteral(
                   filename
                     ? nodePath.relative(
-                        nodePath.parse(filename).dir,
-                        resultPath
-                      )
+                      nodePath.parse(filename).dir,
+                      resultPath
+                    )
                     : shortResultPath
                 )
               )
@@ -374,7 +368,7 @@ export default function({ types: t }) {
                           if (
                             varPath.node.id.name === varName &&
                             varPath.node.init.type ===
-                              `TaggedTemplateExpression`
+                            `TaggedTemplateExpression`
                           ) {
                             varPath.traverse({
                               TaggedTemplateExpression(templatePath) {
@@ -420,7 +414,6 @@ export default function({ types: t }) {
               hookPath.node.arguments.length === 1 &&
               hookPath.node.arguments[0].type === `Identifier`
             ) {
-              return
               const [{ name: varName }] = hookPath.node.arguments
               let binding = hookPath.scope.getBinding(varName)
               if (binding) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,7 +1,7 @@
 const { prepareOptions } = require(`gatsby/dist/utils/babel-loader-helpers`)
 
-exports.prepareOptions = (babel, options) => {
-  const items = prepareOptions(babel, options)
+exports.prepareOptions = (babel, options = {}, resolve = require.resolve) => {
+	const items = prepareOptions(babel, options, resolve)
   
   if (items.length > 2) {
     items[3].splice(

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,8 +1,8 @@
 const { prepareOptions } = require(`gatsby/dist/utils/babel-loader-helpers`)
 
 exports.prepareOptions = (babel, options = {}, resolve = require.resolve) => {
-	const items = prepareOptions(babel, options, resolve)
-  
+  const items = prepareOptions(babel, options, resolve)
+
   if (items.length > 2) {
     items[3].splice(
       0,


### PR DESCRIPTION
`useStaticQuery` hook from `gatsby` is broken. 

This is an attempt to fix it based on commit from `gatsby-source-graphql-universal` whose babel-plugin-remove-graphql-queries file is based on: https://github.com/birkir/gatsby-source-graphql-universal/commit/a68e20d0cad230a778928809300959a95a536788