### PR TITLE
Fix template example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The example template:
 ...
 
 export default ({ data }) => {
-  const { page } = data.wagtail
+  const { page } = data.wagtail.page
 
   return (
     <div>


### PR DESCRIPTION
Before, the template example was defining to extract the page data with `  const page = data.wagtail`. 
This leads to the following use of `{page.title}` having the value `undefined`. 

This issue is caused by a missing level in the returned data. The page data is not available at `data.wagtail`  
but at `data.wagtail.page`. 

The template example is updated and should display the page title as expected in an `h1` tag.