### PR TITLE
Fix preview break when using StreamFieldInterface implementation fragment

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6346,6 +6346,11 @@
         "schema-utils": "^0.4.5"
       }
     },
+    "file-type": {
+      "version": "12.4.2",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-12.4.2.tgz",
+      "integrity": "sha512-UssQP5ZgIOKelfsaB5CuGAL+Y+q7EmONuiwF3N5HAH0t27rvrttgi6Ra9k/+DVaY9UF6+ybxu5pOXLUdA8N7Vg=="
+    },
     "filesize": {
       "version": "3.5.11",
       "resolved": "https://registry.npmjs.org/filesize/-/filesize-3.5.11.tgz",
@@ -7906,6 +7911,247 @@
         "@babel/runtime": "^7.7.6",
         "scroll-behavior": "^0.9.10",
         "warning": "^3.0.0"
+      }
+    },
+    "gatsby-source-filesystem": {
+      "version": "2.3.20",
+      "resolved": "https://registry.npmjs.org/gatsby-source-filesystem/-/gatsby-source-filesystem-2.3.20.tgz",
+      "integrity": "sha512-zwHsOe3BipnGeHvCNz4JSzz9bWbQEFgbpkjCpmOSsPtbNaKKbk7bK8TCLGj268K24x7E5fGuXPTLqXcRfYgEOA==",
+      "requires": {
+        "@babel/runtime": "^7.10.3",
+        "better-queue": "^3.8.10",
+        "bluebird": "^3.7.2",
+        "chokidar": "3.4.0",
+        "file-type": "^12.4.2",
+        "fs-extra": "^8.1.0",
+        "gatsby-core-utils": "^1.3.12",
+        "got": "^9.6.0",
+        "md5-file": "^3.2.3",
+        "mime": "^2.4.6",
+        "pretty-bytes": "^5.3.0",
+        "progress": "^2.0.3",
+        "read-chunk": "^3.2.0",
+        "valid-url": "^1.0.9",
+        "xstate": "^4.11.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.10.5",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.5.tgz",
+          "integrity": "sha512-otddXKhdNn7d0ptoFRHtMLa8LqDxLYwTjB4nYgM1yy5N6gU/MUf8zqyyLltCH3yAVitBzmwK4us+DD0l/MauAg==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "anymatch": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
+          "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
+          "requires": {
+            "normalize-path": "^3.0.0",
+            "picomatch": "^2.0.4"
+          }
+        },
+        "binary-extensions": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
+          "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ=="
+        },
+        "braces": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+          "requires": {
+            "fill-range": "^7.0.1"
+          }
+        },
+        "chokidar": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.0.tgz",
+          "integrity": "sha512-aXAaho2VJtisB/1fg1+3nlLJqGOuewTzQpd/Tz0yTg2R0e4IGtshYvtjowyEumcBv2z+y4+kc75Mz7j5xJskcQ==",
+          "requires": {
+            "anymatch": "~3.1.1",
+            "braces": "~3.0.2",
+            "fsevents": "~2.1.2",
+            "glob-parent": "~5.1.0",
+            "is-binary-path": "~2.1.0",
+            "is-glob": "~4.0.1",
+            "normalize-path": "~3.0.0",
+            "readdirp": "~3.4.0"
+          }
+        },
+        "configstore": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/configstore/-/configstore-5.0.1.tgz",
+          "integrity": "sha512-aMKprgk5YhBNyH25hj8wGt2+D52Sw1DRRIzqBwLp2Ya9mFmY8KPvvtvmna8SxVR9JMZ4kzMD68N22vlaRpkeFA==",
+          "requires": {
+            "dot-prop": "^5.2.0",
+            "graceful-fs": "^4.1.2",
+            "make-dir": "^3.0.0",
+            "unique-string": "^2.0.0",
+            "write-file-atomic": "^3.0.0",
+            "xdg-basedir": "^4.0.0"
+          }
+        },
+        "crypto-random-string": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
+          "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA=="
+        },
+        "dot-prop": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.2.0.tgz",
+          "integrity": "sha512-uEUyaDKoSQ1M4Oq8l45hSE26SnTxL6snNnqvK/VWx5wJhmff5z0FUVJDKDanor/6w3kzE3i7XZOk+7wC0EXr1A==",
+          "requires": {
+            "is-obj": "^2.0.0"
+          }
+        },
+        "fill-range": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+          "requires": {
+            "to-regex-range": "^5.0.1"
+          }
+        },
+        "fsevents": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+          "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+          "optional": true
+        },
+        "gatsby-core-utils": {
+          "version": "1.3.12",
+          "resolved": "https://registry.npmjs.org/gatsby-core-utils/-/gatsby-core-utils-1.3.12.tgz",
+          "integrity": "sha512-58pysrsfe2abWl7TOqeyHgyXSm9UIjYZ7UclGTvczWDYnxl8L/0kPSaFOX+bMmNBZmAB0YEtJZ3gHhM978OvqQ==",
+          "requires": {
+            "ci-info": "2.0.0",
+            "configstore": "^5.0.1",
+            "fs-extra": "^8.1.0",
+            "node-object-hash": "^2.0.0",
+            "proper-lockfile": "^4.1.1",
+            "xdg-basedir": "^4.0.0"
+          }
+        },
+        "glob-parent": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
+          "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+          "requires": {
+            "is-glob": "^4.0.1"
+          }
+        },
+        "got": {
+          "version": "9.6.0",
+          "resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
+          "integrity": "sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==",
+          "requires": {
+            "@sindresorhus/is": "^0.14.0",
+            "@szmarczak/http-timer": "^1.1.2",
+            "cacheable-request": "^6.0.0",
+            "decompress-response": "^3.3.0",
+            "duplexer3": "^0.1.4",
+            "get-stream": "^4.1.0",
+            "lowercase-keys": "^1.0.1",
+            "mimic-response": "^1.0.1",
+            "p-cancelable": "^1.0.0",
+            "to-readable-stream": "^1.0.0",
+            "url-parse-lax": "^3.0.0"
+          }
+        },
+        "is-binary-path": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+          "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+          "requires": {
+            "binary-extensions": "^2.0.0"
+          }
+        },
+        "is-number": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
+        },
+        "is-obj": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
+          "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w=="
+        },
+        "make-dir": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+          "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+          "requires": {
+            "semver": "^6.0.0"
+          }
+        },
+        "mime": {
+          "version": "2.4.6",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
+          "integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA=="
+        },
+        "readdirp": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.4.0.tgz",
+          "integrity": "sha512-0xe001vZBnJEK+uKcj8qOhyAKPzIT+gStxWr3LCB0DwcXR5NZJ3IaC+yGnHCYzB/S7ov3m3EEbZI2zeNvX+hGQ==",
+          "requires": {
+            "picomatch": "^2.2.1"
+          },
+          "dependencies": {
+            "picomatch": {
+              "version": "2.2.2",
+              "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
+              "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg=="
+            }
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.5",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
+          "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+        },
+        "to-regex-range": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+          "requires": {
+            "is-number": "^7.0.0"
+          }
+        },
+        "unique-string": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-2.0.0.tgz",
+          "integrity": "sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==",
+          "requires": {
+            "crypto-random-string": "^2.0.0"
+          }
+        },
+        "write-file-atomic": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
+          "integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
+          "requires": {
+            "imurmurhash": "^0.1.4",
+            "is-typedarray": "^1.0.0",
+            "signal-exit": "^3.0.2",
+            "typedarray-to-buffer": "^3.1.5"
+          }
+        },
+        "xdg-basedir": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-4.0.0.tgz",
+          "integrity": "sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q=="
+        },
+        "xstate": {
+          "version": "4.11.0",
+          "resolved": "https://registry.npmjs.org/xstate/-/xstate-4.11.0.tgz",
+          "integrity": "sha512-v+S3jF2YrM2tFOit8o7+4N3FuFd9IIGcIKHyfHeeNjMlmNmwuiv/IbY9uw7ECifx7H/A9aGLcxPSr0jdjTGDww=="
+        }
       }
     },
     "gatsby-source-graphql": {
@@ -11871,6 +12117,11 @@
       "integrity": "sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==",
       "dev": true
     },
+    "pretty-bytes": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.3.0.tgz",
+      "integrity": "sha512-hjGrh+P926p4R4WbaB6OckyRtO0F0/lQBiT+0gnxjV+5kjPBrfVBFCsCLbMqVQeydvIoouYTCmmEURiH3R1Bdg=="
+    },
     "pretty-error": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/pretty-error/-/pretty-error-2.1.1.tgz",
@@ -11930,6 +12181,16 @@
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
         "react-is": "^16.8.1"
+      }
+    },
+    "proper-lockfile": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.1.tgz",
+      "integrity": "sha512-1w6rxXodisVpn7QYvLk706mzprPTAPCYAqxMvctmPN3ekuRk/kuGkGc82pangZiAt4R3lwSuUzheTTn0/Yb7Zg==",
+      "requires": {
+        "graceful-fs": "^4.1.11",
+        "retry": "^0.12.0",
+        "signal-exit": "^3.0.2"
       }
     },
     "protocols": {
@@ -12384,6 +12645,15 @@
       "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
       "requires": {
         "mute-stream": "~0.0.4"
+      }
+    },
+    "read-chunk": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/read-chunk/-/read-chunk-3.2.0.tgz",
+      "integrity": "sha512-CEjy9LCzhmD7nUpJ1oVOE6s/hBkejlcJEgLQHVnQznOSilOPb+kpKktlLfFDK3/WP43+F80xkUTM2VOkYoSYvQ==",
+      "requires": {
+        "pify": "^4.0.1",
+        "with-open-file": "^0.1.6"
       }
     },
     "read-pkg": {
@@ -14599,6 +14869,11 @@
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-1.1.2.tgz",
       "integrity": "sha512-ejdrifsIydN1XDH7EuR2hn8ZrkRKUYF7tUcBjBy/lhrCvs2K+zRlbW9UHc0IQ9RsYFZJFqJrieoIHfkCa0DBRA=="
     },
+    "valid-url": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/valid-url/-/valid-url-1.0.9.tgz",
+      "integrity": "sha1-HBRHm0DxOXp1eC8RXkCGRHQzogA="
+    },
     "validate-npm-package-license": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
@@ -15111,6 +15386,16 @@
             "ansi-regex": "^5.0.0"
           }
         }
+      }
+    },
+    "with-open-file": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/with-open-file/-/with-open-file-0.1.7.tgz",
+      "integrity": "sha512-ecJS2/oHtESJ1t3ZfMI3B7KIDKyfN0O16miWxdn30zdh66Yd3LsRFebXZXq6GU4xfxLf6nVxp9kIqElb5fqczA==",
+      "requires": {
+        "p-finally": "^1.0.0",
+        "p-try": "^2.1.0",
+        "pify": "^4.0.1"
       }
     },
     "word-wrap": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-source-wagtail",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "apollo-utilities": "^1.3.4",
     "fs-extra": "^8.1.0",
     "gatsby": "^2.13.77",
+    "gatsby-source-filesystem": "^2.3.20",
     "gatsby-source-graphql": "^2.1.8",
     "graphql": "^14.5.0",
     "graphql-2-json-schema": "^0.2.0",

--- a/src/preview.boilerplate.js
+++ b/src/preview.boilerplate.js
@@ -7,14 +7,17 @@ import traverse from 'traverse'
 import { ApolloClient } from 'apollo-client'
 import { gql } from 'apollo-boost'
 import { split } from 'apollo-link'
-import { InMemoryCache, IntrospectionFragmentMatcher } from 'apollo-cache-inmemory'
+import {
+    InMemoryCache,
+    IntrospectionFragmentMatcher,
+} from 'apollo-cache-inmemory'
 import { WebSocketLink } from 'apollo-link-ws'
 import { getMainDefinition } from 'apollo-utilities'
 import { createHttpLink } from 'apollo-link-http'
 import {
     introspectSchema,
     makeRemoteExecutableSchema,
-    mergeSchemas
+    mergeSchemas,
 } from 'graphql-tools'
 
 import { print } from 'graphql/language/printer'
@@ -28,7 +31,7 @@ const PreviewProvider = async (query, fragments = '', onNext) => {
         fieldName,
         url,
         websocketUrl,
-        headers
+        headers,
     } = window.___wagtail.default
     const isolatedQuery = getIsolatedQuery(query, fieldName, typeName)
     const { content_type, token } = decodePreviewUrl()
@@ -44,8 +47,8 @@ const PreviewProvider = async (query, fragments = '', onNext) => {
     let link = createHttpLink({
         uri: url,
         fetchOptions: {
-            headers: { Authorization: token ? `Basic ${getToken()}` : '' }
-        }
+            headers: { Authorization: token ? `Basic ${getToken()}` : '' },
+        },
     })
 
     // If provided create a subscription endpoint
@@ -56,9 +59,9 @@ const PreviewProvider = async (query, fragments = '', onNext) => {
             options: {
                 reconnect: true,
                 connectionParams: {
-                    authToken: getToken()
-                }
-            }
+                    authToken: getToken(),
+                },
+            },
         })
 
         // Alias original link and create one that merges the two
@@ -184,7 +187,7 @@ const PreviewProvider = async (query, fragments = '', onNext) => {
         return {
             imageHeight: Number(imageHeight),
             imageWidth: Number(imageWidth),
-            aspectRatio
+            aspectRatio,
         }
     }
 
@@ -195,7 +198,7 @@ const PreviewProvider = async (query, fragments = '', onNext) => {
                 const {
                     imageWidth,
                     imageHeight,
-                    aspectRatio
+                    aspectRatio,
                 } = computeSharpSize(source, info)
                 return {
                     __typename: 'ImageSharpFixed',
@@ -209,7 +212,7 @@ const PreviewProvider = async (query, fragments = '', onNext) => {
                     srcSet: '',
                     srcWebp: '',
                     srcSetWebp: '',
-                    originalName: ''
+                    originalName: '',
                 }
             },
             fluid: (root, args, context, info) => {
@@ -217,7 +220,7 @@ const PreviewProvider = async (query, fragments = '', onNext) => {
                 const {
                     imageWidth,
                     imageHeight,
-                    aspectRatio
+                    aspectRatio,
                 } = computeSharpSize(source, info)
                 return {
                     __typename: 'ImageSharpFluid',
@@ -233,9 +236,9 @@ const PreviewProvider = async (query, fragments = '', onNext) => {
                     originalImg: source.src,
                     originalName: '',
                     presentationWidth: imageWidth,
-                    presentationHeight: imageHeight
+                    presentationHeight: imageHeight,
                 }
-            }
+            },
         },
         CustomImage: {
             imageFile: (source, args, context, info) => {
@@ -277,34 +280,34 @@ const PreviewProvider = async (query, fragments = '', onNext) => {
                         __typename: 'ImageSharp',
                         fluid: {
                             __typename: 'ImageSharpFluid',
-                            parent: source
+                            parent: source,
                         },
                         fixed: {
                             __typename: 'ImageSharpFixed',
-                            parent: source
+                            parent: source,
                         },
                         original: {
                             __typename: 'ImageSharpOriginal',
                             height: source.height,
                             width: source.width,
-                            src: source.src
-                        }
-                    }
+                            src: source.src,
+                        },
+                    },
                 }
-            }
-        }
+            },
+        },
     }
 
     // Create Apollo client
     const fragmentMatcher = new IntrospectionFragmentMatcher({
-        introspectionQueryResultData
+        introspectionQueryResultData,
     })
     const cache = new InMemoryCache({ fragmentMatcher })
     const client = new ApolloClient({
         cache,
         link,
         typeDefs,
-        resolvers: schemaExtensionResolvers
+        resolvers: schemaExtensionResolvers,
     })
 
     if (content_type && token) {
@@ -318,17 +321,17 @@ const PreviewProvider = async (query, fragments = '', onNext) => {
         // Get first version of preview to render the template
         client
             .query({ query: gql([query]) })
-            .then(result => onNext(result.data || {}))
+            .then((result) => onNext(result.data || {}))
         // Subscribe to any changes...
         client
             .subscribe({
                 query: gql([subscriptionQuery]),
-                variables: {}
+                variables: {},
             })
             .subscribe(
-                response => onNext(response),
-                error => console.log(error),
-                complete => console.log(complete)
+                (response) => onNext(response),
+                (error) => console.log(error),
+                (complete) => console.log(complete)
             )
     }
 }
@@ -339,11 +342,11 @@ export const withPreview = (WrappedComponent, pageQuery, fragments = '') => {
         constructor(props) {
             super(props)
             this.state = {
-                wagtail: cloneDeep(props.data ? props.data.wagtail : {})
+                wagtail: cloneDeep(props.data ? props.data.wagtail : {}),
             }
-            PreviewProvider(pageQuery, fragments, data => {
+            PreviewProvider(pageQuery, fragments, (data) => {
                 this.setState({
-                    wagtail: merge({}, this.state.wagtail, data)
+                    wagtail: merge({}, this.state.wagtail, data),
                 })
             })
         }
@@ -367,26 +370,26 @@ const generatePreviewQuery = (query, contentType, token, fragments) => {
             kind: 'Argument',
             name: {
                 kind: 'Name',
-                value: 'contentType'
+                value: 'contentType',
             },
             value: {
                 block: false,
                 kind: 'StringValue',
-                value: contentType
-            }
+                value: contentType,
+            },
         },
         {
             kind: 'Argument',
             name: {
                 kind: 'Name',
-                value: 'token'
+                value: 'token',
             },
             value: {
                 block: false,
                 kind: 'StringValue',
-                value: token
-            }
-        }
+                value: token,
+            },
+        },
     ]
 
     // Rename query for debugging reasons
@@ -395,14 +398,14 @@ const generatePreviewQuery = (query, contentType, token, fragments) => {
     queryDef.variableDefinitions = []
 
     // Add field to AST
-    const createSelection = name => ({
+    const createSelection = (name) => ({
         kind: 'Field',
         name: {
             kind: 'Name',
-            value: name
+            value: name,
         },
         arguments: [],
-        directives: []
+        directives: [],
     })
 
     // Alter the query so that we can execute it properly
@@ -412,7 +415,7 @@ const generatePreviewQuery = (query, contentType, token, fragments) => {
         if (
             node?.kind == 'Field' &&
             node?.selectionSet?.selections?.find(
-                selection =>
+                (selection) =>
                     selection?.name?.value == 'imageFile' &&
                     (imageFileNode = selection)
             )
@@ -429,21 +432,21 @@ const generatePreviewQuery = (query, contentType, token, fragments) => {
                 kind: 'Directive',
                 name: {
                     kind: 'Name',
-                    value: 'client'
-                }
+                    value: 'client',
+                },
             })
 
             // Replace inline any fragments
             const fragmentTypes = require('gatsby-transformer-sharp/src/fragments.js')
-            traverse(imageFileNode).map(node => {
+            traverse(imageFileNode).map((node) => {
                 if (
                     node?.name?.value == 'fixed' ||
                     node?.name?.value == 'fluid' ||
                     node?.name?.value == 'original'
                 ) {
                     node.selectionSet.selections = node.selectionSet.selections
-                        .map(selection => {
-                            Object.keys(fragmentTypes).map(fragmentName => {
+                        .map((selection) => {
+                            Object.keys(fragmentTypes).map((fragmentName) => {
                                 if (selection?.name?.value == fragmentName) {
                                     const mod = fragmentTypes[fragmentName]
                                     const selections = gql([mod.source])
@@ -454,7 +457,7 @@ const generatePreviewQuery = (query, contentType, token, fragments) => {
                             })
                             return selection
                         })
-                        .filter(selection => !!selection)
+                        .filter((selection) => !!selection)
                 }
             })
 
@@ -468,7 +471,7 @@ const generatePreviewQuery = (query, contentType, token, fragments) => {
     } else {
         queryDef.name = {
             kind: 'Name',
-            value: 'PreviewQuery'
+            value: 'PreviewQuery',
         }
     }
 
@@ -478,18 +481,18 @@ const generatePreviewQuery = (query, contentType, token, fragments) => {
     non-page selections so we override the whole array with just the pages.
   */
     const pageSelections = queryDef.selectionSet.selections.filter(
-        selection => {
+        (selection) => {
             return selection.name.value.toLowerCase() === 'page'
         }
     )
-    pageSelections.map(selection => (selection.arguments = previewArgs))
+    pageSelections.map((selection) => (selection.arguments = previewArgs))
 
     // Change query to subcription type
     const subscriptionQuery = cloneDeep(queryDef)
     subscriptionQuery.operation = 'subscription'
     subscriptionQuery.selectionSet.selections = pageSelections
 
-    const updateFragments = fragments => {
+    const updateFragments = (fragments) => {
         return fragments
             .replace('on ImageSharpFixed', 'on ImageSharpFixed @client')
             .replace('on ImageSharpFluid', 'on ImageSharpFluid @client')
@@ -498,7 +501,7 @@ const generatePreviewQuery = (query, contentType, token, fragments) => {
 
     return {
         query: `${updateFragments(fragments)} ${print(query)}`,
-        subscriptionQuery: `${fragments} ${print(subscriptionQuery)}`
+        subscriptionQuery: `${fragments} ${print(subscriptionQuery)}`,
     }
 }
 

--- a/src/preview.boilerplate.js
+++ b/src/preview.boilerplate.js
@@ -7,7 +7,7 @@ import traverse from 'traverse'
 import { ApolloClient } from 'apollo-client'
 import { gql } from 'apollo-boost'
 import { split } from 'apollo-link'
-import { InMemoryCache } from 'apollo-cache-inmemory'
+import { InMemoryCache, IntrospectionFragmentMatcher } from 'apollo-cache-inmemory'
 import { WebSocketLink } from 'apollo-link-ws'
 import { getMainDefinition } from 'apollo-utilities'
 import { createHttpLink } from 'apollo-link-http'
@@ -296,8 +296,12 @@ const PreviewProvider = async (query, fragments = '', onNext) => {
     }
 
     // Create Apollo client
+    const fragmentMatcher = new IntrospectionFragmentMatcher({
+        introspectionQueryResultData
+    })
+    const cache = new InMemoryCache({ fragmentMatcher })
     const client = new ApolloClient({
-        cache: new InMemoryCache(),
+        cache,
         link,
         typeDefs,
         resolvers: schemaExtensionResolvers


### PR DESCRIPTION
As described in #21, the preview used to break when a StreamFieldInterface implementation fragment (like `... on ImageChooserBlock`) is used in the page query. 

The developer console would show an Apollo error message that is suggesting a solution. The possible solution is also mentioned #21 and comes down to the use if the `IntrospectionFragmentMatcher` from `'apollo-cache-inmemory'`. 

StreamFieldInterface implementation fragment (like `... on ImageChooserBlock`) can now be used without issue. 

Also, `gatsby-source-filesystem` is added to the dependencies since it is required in this plugin's `gatsby-node.js`.

Fixes #21  

