### PR TITLE
Fix: latest gatsby version breaks this package develop and build scripts

### DIFF
--- a/src/babel-loader.js
+++ b/src/babel-loader.js
@@ -1,19 +1,13 @@
-'use strict'
+"use strict";
 
-var _interopRequireDefault = require('@babel/runtime/helpers/interopRequireDefault')
+const babelLoader = require(`babel-loader`);
 
-var _objectWithoutPropertiesLoose2 = _interopRequireDefault(
-    require('@babel/runtime/helpers/objectWithoutPropertiesLoose')
-)
+const {
+  getCustomOptions,
+  mergeConfigItemOptions,
+} = require(`gatsby/dist/utils/babel-loader-helpers`);
 
-const babelLoader = require(`babel-loader`)
-
-const _require = require(`gatsby/dist/utils/babel-loader-helpers`),
-    getCustomOptions = _require.getCustomOptions,
-    mergeConfigItemOptions = _require.mergeConfigItemOptions
-
-const _require2 = require(`./utils`),
-    prepareOptions = _require2.prepareOptions
+const { prepareOptions } = require(`./utils`);
 /**
  * Gatsby's custom loader for webpack & babel
  *
@@ -30,73 +24,69 @@ const _require2 = require(`./utils`),
  * You can find documentation for the custom loader here: https://babeljs.io/docs/en/next/babel-core.html#loadpartialconfig
  */
 
-module.exports = babelLoader.custom(babel => {
-    const toReturn = {
-        // Passed the loader options.
-        customOptions(_ref) {
-            let _ref$stage = _ref.stage,
-                stage = _ref$stage === void 0 ? `test` : _ref$stage,
-                options = (0, _objectWithoutPropertiesLoose2.default)(_ref, [
-                    'stage'
-                ])
-            return {
-                custom: {
-                    stage
-                },
-                loader: Object.assign(
-                    {
-                        cacheDirectory: true,
-                        sourceType: `unambiguous`
-                    },
-                    getCustomOptions(stage),
-                    options
-                )
-            }
+module.exports = babelLoader.custom((babel) => {
+  const toReturn = {
+    // Passed the loader options.
+    customOptions({ stage = `test`, reactRuntime = `classic`, ...options }) {
+      return {
+        custom: {
+          stage,
+          reactRuntime,
         },
+        loader: {
+          cacheDirectory: true,
+          sourceType: `unambiguous`,
+          ...getCustomOptions(stage),
+          ...options,
+        },
+      };
+    },
 
-        // Passed Babel's 'PartialConfig' object.
-        config(partialConfig, { customOptions }) {
-            let options = partialConfig.options
+    // Passed Babel's 'PartialConfig' object.
+    config(partialConfig, { customOptions }) {
+      let { options } = partialConfig;
+      const [
+        reduxPresets,
+        reduxPlugins,
+        requiredPresets,
+        requiredPlugins,
+        fallbackPresets,
+      ] = prepareOptions(babel, customOptions); // If there is no filesystem babel config present, add our fallback
+      // presets/plugins.
 
-            const _prepareOptions = prepareOptions(babel, customOptions),
-                reduxPresets = _prepareOptions[0],
-                reduxPlugins = _prepareOptions[1],
-                requiredPresets = _prepareOptions[2],
-                requiredPlugins = _prepareOptions[3],
-                fallbackPresets = _prepareOptions[4] // If there is no filesystem babel config present, add our fallback
-            // presets/plugins.
+      if (!partialConfig.hasFilesystemConfig()) {
+        options = {
+          ...options,
+          plugins: requiredPlugins,
+          presets: [...fallbackPresets, ...requiredPresets],
+        };
+      } else {
+        // With a babelrc present, only add our required plugins/presets
+        options = {
+          ...options,
+          plugins: [...options.plugins, ...requiredPlugins],
+          presets: [...options.presets, ...requiredPresets],
+        };
+      } // Merge in presets/plugins added from gatsby plugins.
 
-            if (!partialConfig.hasFilesystemConfig()) {
-                options = Object.assign({}, options, {
-                    plugins: requiredPlugins,
-                    presets: [...fallbackPresets, ...requiredPresets]
-                })
-            } else {
-                // With a babelrc present, only add our required plugins/presets
-                options = Object.assign({}, options, {
-                    plugins: [...options.plugins, ...requiredPlugins],
-                    presets: [...options.presets, ...requiredPresets]
-                })
-            } // Merge in presets/plugins added from gatsby plugins.
-
-            reduxPresets.forEach(preset => {
-                options.presets = mergeConfigItemOptions({
-                    items: options.presets,
-                    itemToMerge: preset,
-                    type: `preset`,
-                    babel
-                })
-            })
-            reduxPlugins.forEach(plugin => {
-                options.plugins = mergeConfigItemOptions({
-                    items: options.plugins,
-                    itemToMerge: plugin,
-                    type: `plugin`,
-                    babel
-                })
-            })
-            return options
-        }
-    }
-    return toReturn
-})
+      reduxPresets.forEach((preset) => {
+        options.presets = mergeConfigItemOptions({
+          items: options.presets,
+          itemToMerge: preset,
+          type: `preset`,
+          babel,
+        });
+      });
+      reduxPlugins.forEach((plugin) => {
+        options.plugins = mergeConfigItemOptions({
+          items: options.plugins,
+          itemToMerge: plugin,
+          type: `plugin`,
+          babel,
+        });
+      });
+      return options;
+    },
+  };
+  return toReturn;
+});


### PR DESCRIPTION
In the latest Gatsby version (2.24.63 for me), there are errors related to reactRuntime being undefined.
You can learn more in these issues
https://github.com/gatsbyjs/gatsby/issues/26736
https://github.com/prismicio/gatsby-source-graphql-universal/issues/13

This PR takes the babel-loader.js file from `gatsby-source-graphql-universal` (in this PR https://github.com/prismicio/gatsby-source-graphql-universal/pull/12)
I thought that using a not so minified version of babel-loader.js could help debug it in the future.