### PR TITLE
Add dependency gatsby-transformer-sharp

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "gatsby": "^2.13.77",
     "gatsby-source-filesystem": "^2.3.20",
     "gatsby-source-graphql": "^2.1.8",
+    "gatsby-transformer-sharp": "^2.5.6",
     "graphql": "^14.5.0",
     "graphql-2-json-schema": "^0.2.0",
     "graphql-tag": "^2.10.0",


### PR DESCRIPTION
If `gatsby-source-wagtail` is installed into a relatively plain project
that does not have many other dependencies, it can easily happen that
the `gatsby-transformer-sharp` plugin is not installed.

This leads to errors, because `preview.boilerplate.js` contains the
following line (440):
```js
const fragmentTypes = require('gatsby-transformer-sharp/src/fragments.js')
```

The dependency on `gatsby-transformer-sharp` is now listed and automatically 
installed  when `gatsby-source-wagtail` is installed. 

The defined version (2.5.6) is based on an example project I was working on a while
back. It would probably make sense to test lower versions of this
dependency as well.